### PR TITLE
Setting @message.sender_ip

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -12,15 +12,15 @@ class MessagesController < ApplicationController
     # To keep the structure consistent, we'll build the json
     # structure with the default properties.
     #
-    # This will also help other developers understand what 
+    # This will also help other developers understand what
     # is returned by the server by looking at this method.
-    default_json_structure = { 
-      :status => type, 
-      :html => nil, 
-      :message => nil, 
+    default_json_structure = {
+      :status => type,
+      :html => nil,
+      :message => nil,
       :to => nil }.merge(hash)
 
-    render_options = {:json => default_json_structure}  
+    render_options = {:json => default_json_structure}
     render_options[:status] = 400 if type == :error
 
     render(render_options)
@@ -33,7 +33,7 @@ class MessagesController < ApplicationController
 
     unless @message.nil?
       @results = Message.retrieve_message(params[:stub], @message, request.remote_ip)
-      
+
       if @results[:read]
         respond_to do |format|
           format.html { render :action => "was_read", :notice => @results }
@@ -68,11 +68,12 @@ class MessagesController < ApplicationController
   # POST /n.json
   def create
     @message = Message.new(params[:message])
+    @message.sender_ip = request.remote_ip if APP_TRACK_IP
 
-    respond_to do |format|      
+    respond_to do |format|
       if @message.save
         @key_url = "#{request.protocol + request.host_with_port}/#{@message.key}"
-        
+
         format.json { render_json_response :ok, :message => @key_url }
         format.js { render :action => "success"}
       else

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -17,14 +17,14 @@ class Message < ActiveRecord::Base
       body = CeloxCrypto.decrypt(key, m.body)
       m.read_at = Time.now
       m.body = APP_READ_MARKER # => body cannot be blank
-      
+
       m.recipient_ip = remote_ip if APP_TRACK_IP
 
       m.save
 
       return { :read => false, :body => body }
     end
-      
+
     return { :read => true, :read_at => m.read_at, :recipient_ip => m.recipient_ip }
   end
 
@@ -41,11 +41,9 @@ private
       self.stub = CeloxCrypto.hash_key(key)
       self.created_at = Time.now
       self.expires_at = Time.now + 15.days
-      self.sender_ip = remote_ip if APP_TRACK_IP
-   rescue
-     return false
-   end
-
+    rescue
+      return false
+    end
     true
   end
 end


### PR DESCRIPTION
I noticed when APP_TRACK_IP was set to true that every new message creation would come back with: 

> "Oops! You forgot to give me something to protect."

I tracked down the problem to the model class, where I saw it was failing to set the sender_ip instance variable, which seems to be because models don't have any notion of web request information unless you pass it to them. I fixed it by setting the sender_ip value in the controller (cheap and cheerful).
